### PR TITLE
Corrected require to reference the library by its correct package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dice(); // => 11
 ## Node.js Usage
 
 ```javascript
-var RNG = require('rng');
+var RNG = require('rng-js');
 ```
 
 This module can also be [browserified][browserify] thanks to


### PR DESCRIPTION
With `require(rng)` the library cannot be found, and it can be confused with the `rng` node package, whereas in fact this node package is `rng-js`.
