### PR TITLE
ES6 export working on rng-js

### DIFF
--- a/rng.js
+++ b/rng.js
@@ -231,3 +231,6 @@ RNG.roller = function(expr, rng) {
 
 /* Provide a pre-made generator instance. */
 RNG.$ = new RNG();
+
+// common js
+if (typeof exports !== 'undefined') exports.RNG = RNG;


### PR DESCRIPTION
I tested it on webpack, common-js and browser and worked as well

In pure browser that will do nothing, since vanilla javascript without `type="module"` don't accept the `export` token :smiley: 